### PR TITLE
Adding inline link support and fixing list issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@
  6. You will get an email at your Google Account containing the HTML
     output of the Google Doc with inline images.
 
-  [1]: https://raw.githubusercontent.com/oazabir/GoogleDoc2Html/master/code.js
+  [1]: https://github.com/trjohnst/GoogleDoc2Html/raw/master/code.js

--- a/code.js
+++ b/code.js
@@ -99,9 +99,7 @@ function processItem(item, listCounters, images) {
       if (gt === DocumentApp.GlyphType.BULLET
           || gt === DocumentApp.GlyphType.HOLLOW_BULLET
           || gt === DocumentApp.GlyphType.SQUARE_BULLET) {
-        prefix = '<ul><li>', suffix = "</li>";
-
-          suffix += "</ul>";
+          prefix = '<ul><li>', suffix = "</li>";
         }
       else {
         // Ordered list (<ol>):

--- a/code.js
+++ b/code.js
@@ -159,73 +159,57 @@ function processText(item, output) {
   var text = item.getText();
   var indices = item.getTextAttributeIndices();
 
-  if (indices.length <= 1) {
-    // Assuming that a whole para fully italic is a quote
-    if(item.isBold()) {
-      output.push('<strong>' + text + '</strong>');
+  for (var i=0; i < indices.length; i ++) {
+    var partAtts = item.getAttributes(indices[i]);
+    var startPos = indices[i];
+    var endPos = i+1 < indices.length ? indices[i+1]: text.length;
+    var partText = text.substring(startPos, endPos);
+    
+    Logger.log(partText);
+    
+    
+    if (partAtts.LINK_URL) {
+      output.push('<a href="' + partAtts.LINK_URL + '">');
     }
-    else if(item.isItalic()) {
-      output.push('<blockquote>' + text + '</blockquote>');
+    if (partAtts.ITALIC) {
+      output.push('<i>');
     }
-    else if (text.trim().indexOf('http://') == 0) {
-      output.push('<a href="' + text + '" rel="nofollow">' + text + '</a>');
+    if (partAtts.BOLD) {
+      output.push('<strong>');
+    }
+    if (partAtts.UNDERLINE && !partAtts.LINK_URL) {
+      output.push('<u>');
+    }
+    
+    // If someone has written [xxx] and made this whole text some special font, like superscript
+    // then treat it as a reference and make it superscript.
+    // Unfortunately in Google Docs, there's no way to detect superscript
+    if (partText.indexOf('[')==0 && partText[partText.length-1] == ']') {
+      output.push('<sup>' + partText + '</sup>');
+    }
+    else if (partText.trim().indexOf('http://') == 0) {
+      output.push('<a href="' + partText + '" rel="nofollow">' + partText + '</a>');
     }
     else {
-      output.push(text);
+      output.push(partText);
     }
-  }
-  else {
-
-    for (var i=0; i < indices.length; i ++) {
-      var partAtts = item.getAttributes(indices[i]);
-      var startPos = indices[i];
-      var endPos = i+1 < indices.length ? indices[i+1]: text.length;
-      var partText = text.substring(startPos, endPos);
-
-      Logger.log(partText);
-      
-      if (partAtts.LINK_URL) {
-        output.push('<a href="' + partAtts.LINK_URL + '">');
-      }
-      if (partAtts.ITALIC) {
-        output.push('<i>');
-      }
-      if (partAtts.BOLD) {
-        output.push('<strong>');
-      }
-      if (partAtts.UNDERLINE && !partAtts.LINK_URL) {
-        output.push('<u>');
-      }
-
-      // If someone has written [xxx] and made this whole text some special font, like superscript
-      // then treat it as a reference and make it superscript.
-      // Unfortunately in Google Docs, there's no way to detect superscript
-      if (partText.indexOf('[')==0 && partText[partText.length-1] == ']') {
-        output.push('<sup>' + partText + '</sup>');
-      }
-      else if (partText.trim().indexOf('http://') == 0) {
-        output.push('<a href="' + partText + '" rel="nofollow">' + partText + '</a>');
-      }
-      else {
-        output.push(partText);
-      }
-
-      if (partAtts.UNDERLINE && !partAtts.LINK_URL) {
-        output.push('</u>');
-      }
-      if (partAtts.BOLD) {
-        output.push('</strong>');
-      }
-      if (partAtts.ITALIC) {
-        output.push('</i>');
-      }
-      if (partAtts.LINK_URL) {
-        output.push('</a>');
-      }
-
+    
+    if (partAtts.UNDERLINE && !partAtts.LINK_URL) {
+      output.push('</u>');
     }
+    if (partAtts.BOLD) {
+      output.push('</strong>');
+    }
+    if (partAtts.ITALIC) {
+      output.push('</i>');
+    }
+    if (partAtts.LINK_URL) {
+      output.push('</a>');
+    }
+    
   }
 }
+
 
 
 function processImage(item, images, output)

--- a/code.js
+++ b/code.js
@@ -111,7 +111,12 @@ function processItem(item, listCounters, images) {
       suffix = "</li>";
     }
 
-    if (item.isAtDocumentEnd() || (item.getNextSibling() && (item.getNextSibling().getType() != DocumentApp.ElementType.LIST_ITEM))) {
+    var isAtEnd = item.isAtDocumentEnd();
+    var nextSibling = item.getNextSibling();
+    var listItemType = DocumentApp.ElementType.LIST_ITEM;
+    var isNextAtEndOfList = (!nextSibling || (nextSibling && (nextSibling.getType() != listItemType)));
+    
+    if (isAtEnd || isNextAtEndOfList) {
       if (gt === DocumentApp.GlyphType.BULLET
           || gt === DocumentApp.GlyphType.HOLLOW_BULLET
           || gt === DocumentApp.GlyphType.SQUARE_BULLET) {

--- a/code.js
+++ b/code.js
@@ -183,14 +183,17 @@ function processText(item, output) {
       var partText = text.substring(startPos, endPos);
 
       Logger.log(partText);
-
+      
+      if (partAtts.LINK_URL) {
+        output.push('<a href="' + partAtts.LINK_URL + '">');
+      }
       if (partAtts.ITALIC) {
         output.push('<i>');
       }
       if (partAtts.BOLD) {
         output.push('<strong>');
       }
-      if (partAtts.UNDERLINE) {
+      if (partAtts.UNDERLINE && !partAtts.LINK_URL) {
         output.push('<u>');
       }
 
@@ -207,14 +210,17 @@ function processText(item, output) {
         output.push(partText);
       }
 
-      if (partAtts.ITALIC) {
-        output.push('</i>');
+      if (partAtts.UNDERLINE && !partAtts.LINK_URL) {
+        output.push('</u>');
       }
       if (partAtts.BOLD) {
         output.push('</strong>');
       }
-      if (partAtts.UNDERLINE) {
-        output.push('</u>');
+      if (partAtts.ITALIC) {
+        output.push('</i>');
+      }
+      if (partAtts.LINK_URL) {
+        output.push('</a>');
       }
 
     }


### PR DESCRIPTION
I discovered @thejimbirch's fork of GoogleDoc2Html and it was perfect for a project I was working on to transcribe a google doc handed off by a client that needed it as a static HTML page on their site. Because the doc heavily used lists and inline links, I stumbled into a few issues on the HTML export side. This PR aims to fix the issues that I encountered and merge them upstream.